### PR TITLE
Fixed gpkg export bug

### DIFF
--- a/src/csf_prf/engines/CompositeSourceCreatorEngine.py
+++ b/src/csf_prf/engines/CompositeSourceCreatorEngine.py
@@ -130,7 +130,7 @@ class CompositeSourceCreatorEngine(Engine):
             expression = "'Survey: ' + str(!registry_n!) + ', Priority: ' + str(!priority!) + ', Name: ' + str(!sub_locali!)"
             self.add_column_and_constant(layer, 'invreq', expression)
             outer_features, inner_features = self.split_inner_polygons(layer)
-            self.write_features_to_featureclass('sheets', layer, outer_features + inner_features, 'output_sheets')
+            self.write_sheets_to_featureclass('sheets', layer, outer_features + inner_features, 'output_sheets')
             self.sheets_layer = layer  # Set sheets layer for later use
 
     def convert_tides(self) -> None:
@@ -351,7 +351,7 @@ class CompositeSourceCreatorEngine(Engine):
         arcpy.AddMessage('Done')
         arcpy.AddMessage(f'Run time: {(time.time() - start) / 60}')
 
-    def write_features_to_featureclass(self, output_data_type, template_layer, features, feature_class_name) -> None:
+    def write_sheets_to_featureclass(self, output_data_type, template_layer, features, feature_class_name) -> None:
         """
         Store processed layer as an output feature class
         :param str output_data_type: Name of input parameter type being stored; see param_lookup
@@ -377,7 +377,7 @@ class CompositeSourceCreatorEngine(Engine):
                     fields.append(field.name)
 
         with arcpy.da.InsertCursor(output_name, fields) as cursor:
-            # TODO update for points, lines, and polygons
+            # This adds the inner sheets polygons that were found to the output dataset
             for feature in features:
                 vertices = [(point.X, point.Y) for point in feature['geometry']]
                 polygon = list(vertices)

--- a/src/csf_prf/engines/Engine.py
+++ b/src/csf_prf/engines/Engine.py
@@ -106,12 +106,9 @@ class Engine:
         arcpy.management.CreateSQLiteDatabase(csfprf_output_path, spatial_type='GEOPACKAGE')
         for enc_feature_type, feature_class in self.output_data.items():
             if feature_class:
-                arcpy.AddMessage(f" - Exporting: {enc_feature_type}")
-                if (
-                    "enc" in enc_feature_type
-                    and "GC" not in enc_feature_type
-                    and enc_feature_type != "enc_files"
-                ):  # TODO is 'enc_files' even an option anymore?
+                if ("enc" in enc_feature_type and "GC" not in enc_feature_type):
+                    # Export to csf_prf_geopackage.gpkg as well as CARIS gpkg files
+                    self.export_to_geopackage(csfprf_output_path, enc_feature_type, feature_class)
                     output_path = os.path.join(
                         self.param_lookup["output_folder"].valueAsText, enc_feature_type
                     )


### PR DESCRIPTION
Fixed the following bugs:
1. Point, LintString, and Polygon layers were not being exported to the csf_prf_features.gpkg geopackage if the CARIS export option was selected
    - Added the export method call to the CARIS logic so that it exports a CARIS gpkg and the regular gpkg
3. Duplicate messages were being displayed during export about the Sheets layer. 
    - Moved the export method call to the top of the CARIS logic which contained the main export message and removed the additional export message from the CARIS method